### PR TITLE
Fix checking headers and cookies in response from redirection

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -37,4 +37,6 @@ springBootVersion = 2.1.15.RELEASE
 micronautVersion=2.4.0
 micronautCompactVersion=1.3.7
 kotlinVersion=1.6.21
+ersatzVersion=1.9.0
+undertowVersion=2.0.13.Final
 

--- a/libs/gru-http/gru-http.gradle
+++ b/libs/gru-http/gru-http.gradle
@@ -23,7 +23,6 @@ dependencies {
     compileOnly "org.codehaus.groovy:groovy:$groovyVersion"
 
     testImplementation "com.stehno.ersatz:ersatz:$ersatzVersion"
-    testImplementation 'javax.activation:activation:1.1.1'
     testImplementation "io.undertow:undertow-core:$undertowVersion"
-    testImplementation 'org.slf4j:slf4j-nop:2.0.5'
+    testImplementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.20.0'
 }

--- a/libs/gru-http/gru-http.gradle
+++ b/libs/gru-http/gru-http.gradle
@@ -21,4 +21,9 @@ dependencies {
     api "com.squareup.okhttp3:okhttp:${okHttpVersion}"
 
     compileOnly "org.codehaus.groovy:groovy:$groovyVersion"
+
+    testImplementation "com.stehno.ersatz:ersatz:$ersatzVersion"
+    testImplementation 'javax.activation:activation:1.1.1'
+    testImplementation "io.undertow:undertow-core:$undertowVersion"
+    testImplementation 'org.slf4j:slf4j-nop:2.0.5'
 }

--- a/libs/gru-http/src/main/java/com/agorapulse/gru/http/GruHttpResponse.java
+++ b/libs/gru-http/src/main/java/com/agorapulse/gru/http/GruHttpResponse.java
@@ -18,6 +18,7 @@
 package com.agorapulse.gru.http;
 
 import com.agorapulse.gru.Client;
+import com.agorapulse.gru.cookie.Cookie;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
 
@@ -48,6 +49,9 @@ class GruHttpResponse implements Client.Response {
 
     @Override
     public List<String> getHeaders(String name) {
+        if (response.priorResponse() != null && response.priorResponse().isRedirect()) {
+            return response.priorResponse().headers(name);
+        }
         return response.headers(name);
     }
 
@@ -67,4 +71,12 @@ class GruHttpResponse implements Client.Response {
         return priorResponse == null ? null : priorResponse.header("Location");
     }
 
+    @Override
+    public List<Cookie> getCookies() {
+        if (response.priorResponse() != null &&
+            response.priorResponse().isRedirect()) {
+            return Cookie.parseAll(response.priorResponse().headers("Set-Cookie"));
+        }
+        return Client.Response.super.getCookies();
+    }
 }

--- a/libs/gru-http/src/test/groovy/com/agorapulse/gru/http/HttpRedirectSpec.groovy
+++ b/libs/gru-http/src/test/groovy/com/agorapulse/gru/http/HttpRedirectSpec.groovy
@@ -1,0 +1,76 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2018-2023 Agorapulse.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.agorapulse.gru.http
+
+import com.agorapulse.gru.Gru
+import com.stehno.ersatz.ContentType
+import com.stehno.ersatz.ErsatzServer
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+class HttpRedirectSpec extends Specification {
+
+    @AutoCleanup @Shared ErsatzServer server = new ErsatzServer({
+        autoStart(true)
+    })
+
+    @Shared Gru gru = Gru.create(Http.create(this))
+
+    void setup() {
+        server.expectations {
+            get('/test') {
+                responds()
+                    .cookie('Test-Cookie', 'true')
+                    .header('Location', '/test/1')
+                    .code(303)
+                    .body('')
+
+            }
+            get('/test/1') {
+                responds()
+                    .code(200)
+                    .body('{"message":"OK"}', ContentType.APPLICATION_JSON)
+            }
+        }
+
+        gru.prepare(server.httpUrl('/'))
+    }
+
+    void 'expect cookie from original response when redirecting'() {
+        expect:
+        gru.test {
+            get('/test')
+            expect {
+                status SEE_OTHER
+                cookie 'Test-Cookie', 'true'
+            }
+        }
+    }
+
+    void 'expect header from original response when redirecting'() {
+        expect:
+        gru.test {
+            get('/test')
+            expect {
+                status SEE_OTHER
+                header 'Location', '/test/1'
+            }
+        }
+    }
+}

--- a/libs/gru/gru.gradle
+++ b/libs/gru/gru.gradle
@@ -24,6 +24,7 @@ dependencies {
     api group: 'org.jsoup', name: 'jsoup', version: jsoupVersion
 
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.6'
+    implementation 'org.hamcrest:hamcrest:2.2'
 
     compileOnly "org.codehaus.groovy:groovy:$groovyVersion"
     compileOnly 'org.jetbrains:annotations:13.0'

--- a/libs/gru/src/test/groovy/com/agorapulse/gru/DefaultTestDefinitionBuilderSpec.groovy
+++ b/libs/gru/src/test/groovy/com/agorapulse/gru/DefaultTestDefinitionBuilderSpec.groovy
@@ -72,12 +72,15 @@ class DefaultTestDefinitionBuilderSpec extends Specification {
         String expectedHeader = "X-Foo"
 
         Client.Request request = Mock(Client.Request)
-        Client.Response response = Mock(Client.Response)
+        Client.Response response = Mock(Client.Response) {
+            getStatus() >> 200
+        }
 
         Client client = Mock(Client) {
             getInitialSquad() >> []
             getRequest() >> request
             getResponse() >> response
+            run(_,_) >> { args -> args[1]}
         }
 
         response.getHeaders(expectedHeader) >> ["Bar", "Baz"]


### PR DESCRIPTION
## Summary

This PR fixes the issue with missing headers and cookies in the response object when testing redirections. It turns out that when the server does a redirection, the `response` object inside the `expect` closure has information about the redirection HTTP status code, but whenever you want to check headers or cookies, you don't have an access to it, because the `response` object at that time point to the empty response from the redirection target.

The suggested fix is similar to how the `status()` method works in case of redirection - it checks if there's a prior response and if it is a redirection. If so, it returns headers and cookies from the original response.