### PR TITLE
always verify on close

### DIFF
--- a/examples/heist-micronaut/src/test/groovy/heist/VerificationSpec.groovy
+++ b/examples/heist-micronaut/src/test/groovy/heist/VerificationSpec.groovy
@@ -1,0 +1,49 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2018-2024 Agorapulse.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package heist
+
+import com.agorapulse.gru.Gru
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.PendingFeature
+import spock.lang.Specification
+
+@MicronautTest
+class VerificationSpec extends Specification {
+
+    @Inject Gru gru
+
+    Runnable mockRunnable = Mock()
+
+    // using pending feature guarantees that the test is executed and the assertion error is expected
+    @PendingFeature
+    void 'test it works'() {
+        when:
+            gru.test {
+                get '/moons/earth/moon'
+                expect {
+                    json 'moon.json'
+                }
+            }
+        then:
+            gru.verify()
+
+            1 * mockRunnable.run()
+    }
+
+}

--- a/examples/heist-micronaut/src/test/groovy/heist/micronaut/SlackAppController.java
+++ b/examples/heist-micronaut/src/test/groovy/heist/micronaut/SlackAppController.java
@@ -20,7 +20,6 @@ package heist.micronaut;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.MediaType;
-import io.micronaut.http.annotation.Body;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Post;
 

--- a/examples/heist-micronaut/src/test/resources/heist/VerificationSpec/moon.json
+++ b/examples/heist-micronaut/src/test/resources/heist/VerificationSpec/moon.json
@@ -1,0 +1,5 @@
+{
+  "name": "charon",
+  "planet": "pluto",
+  "created": "${json-unit.ignore}"
+}

--- a/examples/heist/src/test/groovy/heist/HttpTest.java
+++ b/examples/heist/src/test/groovy/heist/HttpTest.java
@@ -18,7 +18,6 @@
 package heist;
 
 import com.agorapulse.gru.Gru;
-import com.agorapulse.gru.http.Http;
 import org.junit.Test;
 
 public class HttpTest {

--- a/libs/gru-micronaut/src/main/java/com/agorapulse/gru/micronaut/GruApplicationRefreshListener.java
+++ b/libs/gru-micronaut/src/main/java/com/agorapulse/gru/micronaut/GruApplicationRefreshListener.java
@@ -1,0 +1,39 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2018-2024 Agorapulse.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.agorapulse.gru.micronaut;
+
+import com.agorapulse.gru.Gru;
+import io.micronaut.context.event.ApplicationEventListener;
+import io.micronaut.runtime.context.scope.refresh.RefreshEvent;
+import jakarta.inject.Singleton;
+
+@Singleton
+public class GruApplicationRefreshListener implements ApplicationEventListener<RefreshEvent> {
+
+    private final Gru gru;
+
+    public GruApplicationRefreshListener(Gru gru) {
+        this.gru = gru;
+    }
+
+    @Override
+    public void onApplicationEvent(RefreshEvent event) {
+        gru.close();
+    }
+
+}

--- a/libs/gru/src/main/java/com/agorapulse/gru/Gru.java
+++ b/libs/gru/src/main/java/com/agorapulse/gru/Gru.java
@@ -124,14 +124,22 @@ public class Gru implements Closeable {
      */
     @Override
     public void close() {
-        if (!verified) {
-            context.throwErrorIfPresent();
-            if (definition) {
-                throw new AssertionError("Test wasn't verified. Call assertion.verify() from the then block manually!");
+        try {
+            if (!verified) {
+                context.throwErrorIfPresent();
+                if (definition) {
+                    try {
+                        squad.verify(client, context);
+                    } catch (Throwable e) {
+                        throw new AssertionError("Exception thrown while verifying the test", e);
+                    }
+                    context.throwErrorIfPresent();
+                    throw new AssertionError("Test wasn't verified. Call assertion.verify() from the then block manually!");
+                }
             }
+        } finally {
+            reset(false);
         }
-
-        reset(false);
     }
 
     /**

--- a/libs/gru/src/test/groovy/com/agorapulse/gru/GruSpec.groovy
+++ b/libs/gru/src/test/groovy/com/agorapulse/gru/GruSpec.groovy
@@ -41,7 +41,7 @@ class GruSpec extends Specification {
             gru.close()
         then:
             AssertionError e = thrown(AssertionError)
-            e.message?.startsWith('Test wasn\'t verified.')
+            e.message?.startsWith('Exception thrown while verifying the test')
     }
 
 }


### PR DESCRIPTION
Due the Spock nature, the verification of the invocations executes before Gru can verify the results, hiding the original error. Now when `gru` instance is closed but not verified then the verification is executed to print the original issue.

## Before
```

Too few invocations for:

1 * mockRunnable.run()   (0 invocations)

Unmatched invocations (ordered by similarity):

None


	at org.spockframework.mock.runtime.InteractionScope.verifyInteractions(InteractionScope.java:104)
	at org.spockframework.mock.runtime.MockController.leaveScope(MockController.java:77)
	at heist.VerificationSpec.test it works(VerificationSpec.groovy:37)
	Suppressed: java.lang.AssertionError: Test wasn't verified. Call assertion.verify() from the then block manually!
		at com.agorapulse.gru.Gru.close(Gru.java:130)
		at com.agorapulse.gru.spock.GruSpockExtension.lambda$visitSpec$1(GruSpockExtension.java:30)
		at org.spockframework.runtime.extension.MethodInvocation.proceed(MethodInvocation.java:101)
		at org.spockframework.runtime.PlatformSpecRunner.invoke(PlatformSpecRunner.java:398)
		at org.spockframework.runtime.PlatformSpecRunner.runFeatureMethod(PlatformSpecRunner.java:324)
		at org.spockframework.runtime.IterationNode.execute(IterationNode.java:50)
		at org.spockframework.runtime.SimpleFeatureNode.execute(SimpleFeatureNode.java:58)
		at org.spockframework.runtime.SimpleFeatureNode.execute(SimpleFeatureNode.java:15)
		at org.spockframework.runtime.SpockNode.sneakyInvoke(SpockNode.java:40)
		at org.spockframework.runtime.IterationNode.lambda$around$0(IterationNode.java:67)
		at org.spockframework.runtime.PlatformSpecRunner.lambda$createMethodInfoForDoRunIteration$5(PlatformSpecRunner.java:236)
		at org.spockframework.runtime.model.MethodInfo.invoke(MethodInfo.java:156)
		at org.spockframework.runtime.PlatformSpecRunner.invokeRaw(PlatformSpecRunner.java:407)
		at org.spockframework.runtime.PlatformSpecRunner.invoke(PlatformSpecRunner.java:390)
		at org.spockframework.runtime.PlatformSpecRunner.runIteration(PlatformSpecRunner.java:218)
		at org.spockframework.runtime.IterationNode.around(IterationNode.java:67)
		at org.spockframework.runtime.SimpleFeatureNode.lambda$around$0(SimpleFeatureNode.java:52)
		at org.spockframework.runtime.SpockNode.sneakyInvoke(SpockNode.java:40)
		at org.spockframework.runtime.FeatureNode.lambda$around$0(FeatureNode.java:41)
		at org.spockframework.runtime.PlatformSpecRunner.lambda$createMethodInfoForDoRunFeature$4(PlatformSpecRunner.java:199)
		at org.spockframework.runtime.model.MethodInfo.invoke(MethodInfo.java:156)
		at org.spockframework.runtime.extension.MethodInvocation.proceed(MethodInvocation.java:102)
		at io.micronaut.test.extensions.spock.MicronautSpockExtension$1.proceed(MicronautSpockExtension.java:80)
		at io.micronaut.test.extensions.AbstractMicronautExtension.interceptEach(AbstractMicronautExtension.java:157)
		at io.micronaut.test.extensions.AbstractMicronautExtension.interceptTest(AbstractMicronautExtension.java:114)
		at io.micronaut.test.extensions.spock.MicronautSpockExtension.lambda$visitSpecAnnotation$0(MicronautSpockExtension.java:72)
		at org.spockframework.runtime.extension.MethodInvocation.proceed(MethodInvocation.java:101)
		at org.spockframework.runtime.PlatformSpecRunner.invoke(PlatformSpecRunner.java:398)
		at org.spockframework.runtime.PlatformSpecRunner.runFeature(PlatformSpecRunner.java:192)
		at org.spockframework.runtime.FeatureNode.around(FeatureNode.java:41)
		at org.spockframework.runtime.SimpleFeatureNode.around(SimpleFeatureNode.java:52)
		at org.spockframework.runtime.SimpleFeatureNode.around(SimpleFeatureNode.java:15)
		at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
		at org.spockframework.runtime.SpockNode.sneakyInvoke(SpockNode.java:40)
		at org.spockframework.runtime.SpecNode.lambda$around$0(SpecNode.java:63)
		at org.spockframework.runtime.PlatformSpecRunner.lambda$createMethodInfoForDoRunSpec$0(PlatformSpecRunner.java:61)
		at org.spockframework.runtime.model.MethodInfo.invoke(MethodInfo.java:156)
		at org.spockframework.runtime.PlatformSpecRunner.invokeRaw(PlatformSpecRunner.java:407)
		at org.spockframework.runtime.PlatformSpecRunner.invoke(PlatformSpecRunner.java:390)
		at org.spockframework.runtime.PlatformSpecRunner.runSpec(PlatformSpecRunner.java:55)
		at org.spockframework.runtime.SpecNode.around(SpecNode.java:63)
		at org.spockframework.runtime.SpecNode.around(SpecNode.java:11)
		at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
```

## After
```
ACTUAL:
{"name":"earth","planet":"moon","created":1714114541.854220000}
EXPECTED:
{
  "name": "charon",
  "planet": "pluto",
  "created": "${json-unit.ignore}"
}

Too few invocations for:

1 * mockRunnable.run()   (0 invocations)

Unmatched invocations (ordered by similarity):

None


	at org.spockframework.mock.runtime.InteractionScope.verifyInteractions(InteractionScope.java:104)
	at org.spockframework.mock.runtime.MockController.leaveScope(MockController.java:77)
	at heist.VerificationSpec.test it works(VerificationSpec.groovy:37)
	Suppressed: java.lang.AssertionError: Exception thrown while verifying the test
		at com.agorapulse.gru.Gru.close(Gru.java:134)
		at com.agorapulse.gru.spock.GruSpockExtension.lambda$visitSpec$1(GruSpockExtension.java:30)
		at org.spockframework.runtime.extension.MethodInvocation.proceed(MethodInvocation.java:101)
		at org.spockframework.runtime.PlatformSpecRunner.invoke(PlatformSpecRunner.java:398)
		at org.spockframework.runtime.PlatformSpecRunner.runFeatureMethod(PlatformSpecRunner.java:324)
		at org.spockframework.runtime.IterationNode.execute(IterationNode.java:50)
		at org.spockframework.runtime.SimpleFeatureNode.execute(SimpleFeatureNode.java:58)
		at org.spockframework.runtime.SimpleFeatureNode.execute(SimpleFeatureNode.java:15)
		at org.spockframework.runtime.SpockNode.sneakyInvoke(SpockNode.java:40)
		at org.spockframework.runtime.IterationNode.lambda$around$0(IterationNode.java:67)
		at org.spockframework.runtime.PlatformSpecRunner.lambda$createMethodInfoForDoRunIteration$5(PlatformSpecRunner.java:236)
		at org.spockframework.runtime.model.MethodInfo.invoke(MethodInfo.java:156)
		at org.spockframework.runtime.PlatformSpecRunner.invokeRaw(PlatformSpecRunner.java:407)
		at org.spockframework.runtime.PlatformSpecRunner.invoke(PlatformSpecRunner.java:390)
		at org.spockframework.runtime.PlatformSpecRunner.runIteration(PlatformSpecRunner.java:218)
		at org.spockframework.runtime.IterationNode.around(IterationNode.java:67)
		at org.spockframework.runtime.SimpleFeatureNode.lambda$around$0(SimpleFeatureNode.java:52)
		at org.spockframework.runtime.SpockNode.sneakyInvoke(SpockNode.java:40)
		at org.spockframework.runtime.FeatureNode.lambda$around$0(FeatureNode.java:41)
		at org.spockframework.runtime.PlatformSpecRunner.lambda$createMethodInfoForDoRunFeature$4(PlatformSpecRunner.java:199)
		at org.spockframework.runtime.model.MethodInfo.invoke(MethodInfo.java:156)
		at org.spockframework.runtime.extension.MethodInvocation.proceed(MethodInvocation.java:102)
		at io.micronaut.test.extensions.spock.MicronautSpockExtension$1.proceed(MicronautSpockExtension.java:80)
		at io.micronaut.test.extensions.AbstractMicronautExtension.interceptEach(AbstractMicronautExtension.java:157)
		at io.micronaut.test.extensions.AbstractMicronautExtension.interceptTest(AbstractMicronautExtension.java:114)
		at io.micronaut.test.extensions.spock.MicronautSpockExtension.lambda$visitSpecAnnotation$0(MicronautSpockExtension.java:72)
		at org.spockframework.runtime.extension.MethodInvocation.proceed(MethodInvocation.java:101)
		at org.spockframework.runtime.PlatformSpecRunner.invoke(PlatformSpecRunner.java:398)
		at org.spockframework.runtime.PlatformSpecRunner.runFeature(PlatformSpecRunner.java:192)
		at org.spockframework.runtime.FeatureNode.around(FeatureNode.java:41)
		at org.spockframework.runtime.SimpleFeatureNode.around(SimpleFeatureNode.java:52)
		at org.spockframework.runtime.SimpleFeatureNode.around(SimpleFeatureNode.java:15)
		at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
		at org.spockframework.runtime.SpockNode.sneakyInvoke(SpockNode.java:40)
		at org.spockframework.runtime.SpecNode.lambda$around$0(SpecNode.java:63)
		at org.spockframework.runtime.PlatformSpecRunner.lambda$createMethodInfoForDoRunSpec$0(PlatformSpecRunner.java:61)
		at org.spockframework.runtime.model.MethodInfo.invoke(MethodInfo.java:156)
		at org.spockframework.runtime.PlatformSpecRunner.invokeRaw(PlatformSpecRunner.java:407)
		at org.spockframework.runtime.PlatformSpecRunner.invoke(PlatformSpecRunner.java:390)
		at org.spockframework.runtime.PlatformSpecRunner.runSpec(PlatformSpecRunner.java:55)
		at org.spockframework.runtime.SpecNode.around(SpecNode.java:63)
		at org.spockframework.runtime.SpecNode.around(SpecNode.java:11)
		at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	Caused by: net.javacrumbs.jsonunit.core.internal.Opentest4jExceptionFactory$JsonAssertError: [Response must match file content: moon.json content] JSON documents are different:
Different value found in node "name", expected: <"charon"> but was: <"earth">.
Different value found in node "planet", expected: <"pluto"> but was: <"moon">.

		at net.javacrumbs.jsonunit.core.internal.Opentest4jExceptionFactory.createException(ExceptionFactory.java:37)
		at net.javacrumbs.jsonunit.core.internal.ExceptionUtils.createException(ExceptionUtils.java:45)
		at net.javacrumbs.jsonunit.core.internal.Diff.failIfDifferent(Diff.java:617)
		at net.javacrumbs.jsonunit.core.internal.matchers.InternalMatcher.isEqualTo(InternalMatcher.java:162)
		at net.javacrumbs.jsonunit.fluent.JsonFluentAssert.isEqualTo(JsonFluentAssert.java:101)
		at com.agorapulse.gru.minions.JsonMinion.similar(JsonMinion.java:100)
		at com.agorapulse.gru.minions.AbstractContentMinion.doVerify(AbstractContentMinion.java:69)
		at com.agorapulse.gru.minions.AbstractMinion.verify(AbstractMinion.java:61)
		at com.agorapulse.gru.Squad.verify(Squad.java:126)
		at com.agorapulse.gru.Gru.close(Gru.java:132)
		... 42 more
```