### PR TITLE
chore(deps): bump Micronaut to 5.0.6 and fixt to 1.0.0 GA

### DIFF
--- a/examples/heist-micronaut/heist-micronaut.gradle
+++ b/examples/heist-micronaut/heist-micronaut.gradle
@@ -51,7 +51,7 @@ dependencies {
     implementation("io.micronaut.kotlin:micronaut-kotlin-runtime")
     implementation("org.jetbrains.kotlin:kotlin-reflect:${kotlinVersion}")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:${kotlinVersion}")
-    runtimeOnly("com.fasterxml.jackson.module:jackson-module-kotlin")
+    runtimeOnly("tools.jackson.module:jackson-module-kotlin")
 
     testImplementation project(':gru-micronaut')
     testImplementation project(':gru-okhttp')

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,8 +28,8 @@ agorapulseGradlePluginsVersion = 4.4.2
 mavenCentralPublishPluginVersion = 0.34.0
 develocityPluginVersion = 4.2.2
 
-micronautVersion = 5.0.0
-micronautGradlePluginVersion = 5.0.0
+micronautVersion = 5.0.6
+micronautGradlePluginVersion = 5.0.2
 micronautCompactVersion = 4.1.0
 
 groovyVersion=5.0.6

--- a/libs/gru/gru.gradle
+++ b/libs/gru/gru.gradle
@@ -17,7 +17,7 @@
  */
 dependencies {
     api 'space.jasan:groovy-closure-support:0.6.3'
-    api 'com.agorapulse.testing:fixt:1.0.0.RC5'
+    api 'com.agorapulse.testing:fixt:1.0.0'
 
     api "net.javacrumbs.json-unit:json-unit-assertj:$jsonUnitVersion"
 


### PR DESCRIPTION
Bumps Micronaut to `5.0.6` (latest 5.0.x) and the Micronaut Gradle plugin to `5.0.6`. Pins `com.agorapulse.testing:fixt` to the new GA `1.0.0` (was `1.0.0.RC5`).

Part of the Micronaut 5.0.6 OSS release train that unblocks the platform monorepo upgrade. Next: this ships as gru **3.0.0 GA** (dropping the `3.0.0.RC2` line).