### PR TITLE
chore(deps): bump Micronaut to 5.1.0 and fix guide title attributes

### DIFF
--- a/docs/guide/guide.gradle
+++ b/docs/guide/guide.gradle
@@ -32,6 +32,9 @@ asciidoctor {
         'source-highlighter': 'prettify',
         'root-dir'          : rootDir,
         'project-slug'      : slug,
+        'project-title'     : 'Gru',
+        'project-version'   : project.version,
+        'project-author'    : 'Agorapulse',
         'docinfo'           : 'shared',
         'toclevels'         : 3,
     ]

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,7 +28,7 @@ agorapulseGradlePluginsVersion = 4.4.2
 mavenCentralPublishPluginVersion = 0.34.0
 develocityPluginVersion = 4.2.2
 
-micronautVersion = 5.0.6
+micronautVersion = 5.1.0
 micronautGradlePluginVersion = 5.0.2
 micronautCompactVersion = 4.1.0
 


### PR DESCRIPTION
Bumps Micronaut 5.0.6 -> 5.1.0 (Gradle plugin stays 5.0.2). Also fixes the published guide rendering literal {project-title}/{project-version} by adding the project-title/version/author asciidoctor attributes. Ships as gru 3.0.1.