### PR TITLE
chore(deps): bump fixt to 1.0.1

### DIFF
--- a/libs/gru/gru.gradle
+++ b/libs/gru/gru.gradle
@@ -17,7 +17,7 @@
  */
 dependencies {
     api 'space.jasan:groovy-closure-support:0.6.3'
-    api 'com.agorapulse.testing:fixt:1.0.0'
+    api 'com.agorapulse.testing:fixt:1.0.1'
 
     api "net.javacrumbs.json-unit:json-unit-assertj:$jsonUnitVersion"
 


### PR DESCRIPTION
Propagates the fixt 1.0.1 GA into gru. Part of the MN 5.1.0 dependency-chain propagation. Ships as gru 3.0.2.